### PR TITLE
Remove TOKEN_SIZE limit on Linux

### DIFF
--- a/src/linux_ping/mod.rs
+++ b/src/linux_ping/mod.rs
@@ -16,8 +16,6 @@ use crate::{IpStatus, PingApiOutput, PingError, PingOptions, PingReply, Result};
 use crate::linux_ping::icmp_header::{ICMP_HEADER_SIZE, IcmpEchoHeader};
 use crate::linux_ping::ping_future::{PingFuture};
 
-const TOKEN_SIZE: usize = 24;
-
 pub fn send_ping(addr: &IpAddr, timeout: Duration, data: &[u8], options: Option<&PingOptions>) -> Result<PingReply> {
     let mut context = match addr {
         IpAddr::V4(_) => PingContext::new::<Ipv4Addr>(addr, timeout, data, options)?,
@@ -125,8 +123,6 @@ fn create_socket<P: Proto>() -> Result<Socket> {
 }
 
 fn make_data<P: Proto>(data: &[u8]) -> Result<Vec<u8>> {
-    if data.len() > TOKEN_SIZE { return Err(PingError::DataSizeTooBig(TOKEN_SIZE)); }
-
     let mut buffer = vec![0; ICMP_HEADER_SIZE + data.len()];
     let mut payload = &mut buffer[ICMP_HEADER_SIZE..];
     if let Err(_) = payload.write(&data){


### PR DESCRIPTION
Closes #6

Some ISPs force you to use a router/modem that support PPPoE with baby jumbo frames (1500 bytes internally, 1508 bytes externally, RFC 4638), so if your ping tool doesn't allow you to set MTU size to 1472 bytes (+28 bytes of overhead = 1500 bytes), you don't know if your router/modem is compatible with your ISP.

I can make the ping data 1472 bytes on Windows, but not on linux.